### PR TITLE
BUGFIX: Unknown variable name in run function.

### DIFF
--- a/rtl_433.py
+++ b/rtl_433.py
@@ -53,7 +53,7 @@ class SignalProcess(RFSignal):
     def run(self, samples):
         # Dumb everything as one stream
         if self.dump_raw:
-            d.tofile(self.dump_raw)
+            samples.tofile(self.dump_raw)
             self.dump_raw.flush()
 
         self.process(samples)
@@ -62,10 +62,10 @@ class SignalProcess(RFSignal):
             self.analyze()
         self.demodulate()
                     
-    def callback(self, samples, rtl):
+    def callback(self, num_samples, rtl):
         try:
-            d = np.frombuffer(samples, dtype=np.uint8)
-            self.run(d)
+            samples = np.frombuffer(num_samples, dtype=np.uint8)
+            self.run(samples)
         except Exception as err:
             print("Error in callback!")
             print(err)


### PR DESCRIPTION
Error: When using the argument --dump-raw the try-block failed with _unknown variable "d"_. 

Fix: Renamed the variable to samples following the function argument name and renamed variables in the callback to reflect the naming of callback arguments.
